### PR TITLE
Rename Aiven for Redis to Aiven for Caching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributions are very welcome on the Aiven netlify-nextjs example. When contrib
 
 # Development
 
-Development of this project requires a PostgreSQL database as well as a Redis database. You can use a local database or use the Aiven for PostgreSQL® and Aiven for Redis® managed databases, available on https://aiven.io.
+Development of this project requires a PostgreSQL database as well as a Redis compatible database. You can use a local database or use the Aiven for PostgreSQL® and Aiven for Caching managed databases, available on https://aiven.io.
 
 ## Local Environment
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -13,7 +13,7 @@ export const Layout: React.FC<{ children: ReactNode }> = ({ children }) => {
     <>
       <Head>
         <title>Recipe library powered by Aiven and Netlify</title>
-        <meta name="description" content="Recipe library built with Next.js, PostgreSQL, Redis and Netlify" />
+        <meta name="description" content="Recipe library built with Next.js, PostgreSQL, Aiven for Caching and Netlify" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/src/lib/ioredis.ts
+++ b/src/lib/ioredis.ts
@@ -16,7 +16,7 @@ const createRedisInstance = () => {
   redis.on('error', () => {
     // eslint-disable-next-line no-console
     console.warn(
-      'Creating Redis instance failed. Results will not cached. Make sure your REDIS_URI environment variable points to a running Aiven for Redis® instance and restart your application.',
+      'Creating Redis instance failed. Results will not cached. Make sure your REDIS_URI environment variable points to a running Aiven for Caching instance and restart your application.',
     );
   });
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,13 +15,13 @@ export default function Home() {
     >
       <Box display="flex" gap="3" justifyContent="center" className="flex-wrap">
         <Chip text="Aiven for PostgreSQL®" />
-        <Chip text="Aiven for Redis®*" />
+        <Chip text="Aiven for Caching" />
       </Box>
       <Typography.LargeHeading>
         Free Netlify quickstart recipe library app using Next.js, Prisma and Aiven
       </Typography.LargeHeading>
       <Typography.Large color="grey-60">
-        A PostgreSQL® and Redis®* optimized Next.js application built with Aiven, Prisma and open source data - for
+        A PostgreSQL® and Aiven for Caching optimized Next.js application built with Aiven, Prisma and open source data - for
         free.
       </Typography.Large>
       <Box.Flex gap="5" justifyContent="center" className="flex-wrap">

--- a/src/pages/recipes/index.tsx
+++ b/src/pages/recipes/index.tsx
@@ -59,11 +59,11 @@ export default function Recipes() {
               {recipeStatsData?.isRedisAvailable && (
                 <Box minWidth="fit">
                   <Switch
-                    caption="Get statistics faster with Redis"
+                    caption="Get statistics faster with Aiven for Caching"
                     onChange={() => setUseRedis(!useRedis)}
                     checked={useRedis}
                   >
-                    Enable Aiven for Redis®*
+                    Enable Aiven for Caching
                   </Switch>
                 </Box>
               )}
@@ -120,16 +120,16 @@ const getStatisticsInfo = (stats: RecipeStatsResponse | undefined, useRedis: boo
   const endToEndRetrievalTime = `${stats?.endToEndRetrievalTimeMs ?? '??'}ms. ${endToEndInfo}`;
 
   if (!stats?.isRedisAvailable) {
-    return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. To get cached results using Aiven for Redis®*, please follow the instructions to set up your Redis instance.`;
+    return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. To get cached results using Aiven for Caching, please follow the instructions to set up your Caching instance.`;
   }
 
   if (useRedis) {
     if (stats.fromCache) {
-      return `Recipe statistics cached in Aiven for Redis®*, retrieved in ${endToEndRetrievalTime}.`;
+      return `Recipe statistics cached in Aiven for Caching, retrieved in ${endToEndRetrievalTime}.`;
     }
 
-    return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. Results are now cached to Aiven for Redis®*.`;
+    return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. Results are now cached to Aiven for Caching.`;
   }
 
-  return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. To get cached results using Aiven for Redis®*, please enable it.`;
+  return `Recipe statistics retrieved from Aiven for PostgreSQL® database in ${endToEndRetrievalTime}. To get cached results using Aiven for Caching, please enable it.`;
 };

--- a/workshop-script.md
+++ b/workshop-script.md
@@ -23,7 +23,7 @@ Show the app actually doing something (look at a recipe) and maybe also look
 in the database to show what’s there (for instance, using psql at the command
 line).
 
-Explain that it's using PostgreSQL as a database, and Redis as a cache to
+Explain that it's using PostgreSQL as a database, and Aiven for Caching as a cache to
 speed up (repeated) database access.
 
 Explain that the application comes with its own data - deploying it loads the
@@ -47,7 +47,7 @@ Check people have an Aiven login, and quickly show them how to get on.
 
 > Aiven signup: https://go.aiven.io/signup-netlify-workshop
 
-Lead them through creating the PostgreSQL and Redis services they’re going to need
+Lead them through creating the PostgreSQL and Aiven for Caching services they’re going to need
 
 > We recommend using `do-nyc` in the North America region to minimise latency, as this region will be closest to where the Netlify free plan deploys its functions.
 
@@ -134,16 +134,16 @@ Show the content of the new netlify.toml file
 > **Note** can use `netlify open` to go to the netlify dashboard for the site
 
 
-## Define which PostgreSQL and Redis the app should use
+## Define which PostgreSQL and Aiven for Caching the app should use
 
 * Go to the Aiven Console, and to the PostgreSQL service page
 * Copy the SERVICE URI
 * Use `netlify env:set DATABASE_URL ‘THE-POSTGRES-SERVICE-URI’` - remember
   we’ll need to quote the URL at the command line
 
-* Go to the Aiven Console, and to the Redis service page
+* Go to the Aiven Console, and to the Aiven for Caching service page
 * Copy the SERVICE URI
-* Use `netlify env:set REDIS_URI ‘THE-REDIS-SERVICE-URI’`
+* Use `netlify env:set REDIS_URI ‘THE-AIVEN-FOR-CACHING-SERVICE-URI’`
 
 `netlify env:list` will show them back
 
@@ -198,14 +198,14 @@ This is Not a Good Thing.
 ## Production and testing
 
 We’re using the same database(s) for both production and testing - this is a
-Bad Idea. We’re doing that because we’re using the free PG and Redis, and a
+Bad Idea. We’re doing that because we’re using the free PG and Aiven for Caching, and a
 user is only allowed one of each - which isn’t a problem for real use cases,
 because the free tier is not suitable for production.
 
 * Switch over to the prod url and show wait a minute, the data is changing when I change it in the test url? Whoops this isn’t good
 * Explain that you probably want to use a different data services set up in pre-prod vs prod
 * Explain that this part is just for demo as we don’t have time to set this all up for everyone
-* Show that there is a new prod postgres and redis already created (presenter did this in the background earlier)
+* Show that there is a new prod postgres and caching already created (presenter did this in the background earlier)
 * Show that we need to update the env variables to have a different URL for the services for prod than for everything else
 * Call out “oh wait, the build command seeds the database! We don’t want to do that every time in prod!”
 * Then say “well wait, lets see what that really does…” look at line 38 in prisma/seed.ts and see that it only does that for a blank DB
@@ -213,7 +213,7 @@ because the free tier is not suitable for production.
 
 
 Talk about using a separate build configuration for production and for testing,
-targetting different PostgreSQL and Redis instances.
+targetting different PostgreSQL and Aiven for Caching instances.
 
 ## What's Prisma?
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Previously known as Aiven for Redis®*. As a result of license change and revised trademark guidance from Redis, Aiven has changed the name of Aiven for Redis® to Aiven for Caching. Aiven for Caching offers all the same functionality as Aiven for Redis®.

